### PR TITLE
feat: refactor texture types

### DIFF
--- a/texture/Cargo.toml
+++ b/texture/Cargo.toml
@@ -12,7 +12,6 @@ exclude = ["example/"]
 [dependencies]
 irondash_engine_context = { version = "0.1.1" }
 irondash_run_loop = { version = "0.1.0" }
-bytes = "1"
 log = "0.4"
 
 [target.'cfg(target_os = "android")'.dependencies]

--- a/texture/README.md
+++ b/texture/README.md
@@ -14,7 +14,7 @@ impl PayloadProvider<BoxedPixelData> for MyPayloadProvider {
     // This method will be called by Flutter during rasterization
     // to get new texture data.
     fn get_payload(&self) -> BoxedPixelData {
-        let data: Vec<u8> = get_pixel_data();
+        let data: Vec<u8> = make_pixel_data(width, height);
         SimplePixelData::boxed(width, height, data)
     }
 }
@@ -39,7 +39,7 @@ To create texture, you need to have handle for current Flutter engine, which you
 Other than `BoxedPixelData`, there are platform specific payload types that can be used to display GPU texture.
 
 - `BoxedIOSurface` that provides `IOSurface` texture on macOS and iOS
-- `BoxedGLTexsture` on Linux
+- `BoxedGLTexture` on Linux
 - `BoxedTextureDescriptor<ID3D11Texture2D>` and `BoxedTextureDescriptor<DxgiSharedHandle>` on Windows
 
 To use GPU texture on Android, instead of setting payload, you can request JNI `Surface` or NDK `ANativeWindow` from the texture:

--- a/texture/README.md
+++ b/texture/README.md
@@ -10,16 +10,12 @@ struct MyPayloadProvider {
     // ...
 }
 
-impl PayloadProvider<PixelBuffer> for MyPayloadProvider {
+impl PayloadProvider<BoxedPixelData> for MyPayloadProvider {
     // This method will be called by Flutter during rasterization
     // to get new texture data.
-    fn get_payload(&self) -> BoxedPayload<PixelBuffer> {
-        let buffer = PixelBuffer {
-            width,
-            height,
-            data,
-        };
-        buffer.into_boxed_payload();
+    fn get_payload(&self) -> BoxedPixelData {
+        let data: Vec<u8> = get_pixel_data();
+        SimplePixelData::boxed(width, height, data)
     }
 }
 ```
@@ -38,13 +34,13 @@ texture.mark_frame_available();
 
 To create texture, you need to have handle for current Flutter engine, which you can obtain through [irondash_engine_context](https://github.com/irondash/irondash/tree/main/engine_context).
 
-`PixelBuffer` payload type is supported on all platforms, though pixel order may change depending on platform. To find out pixel order for current platform use `PixelBuffer::FORMAT`.
+`BoxedPixelData` payload type is supported on all platforms, though pixel order may change depending on platform. To find out pixel order for current platform use `PixelData::FORMAT`.
 
-Other than `PixelBuffer`, there are platform specific payload types that can be used to display GPU texture.
+Other than `BoxedPixelData`, there are platform specific payload types that can be used to display GPU texture.
 
-- `IOSurface` on macOS and iOS
-- `GLTexture` on Linux
-- `TextureDescriptor<ID3D11Texture2D>` and `TextureDescriptor<DxgiSharedHandle>` on Windows
+- `BoxedIOSurface` that provides `IOSurface` texture on macOS and iOS
+- `BoxedGLTexsture` on Linux
+- `BoxedTextureDescriptor<ID3D11Texture2D>` and `BoxedTextureDescriptor<DxgiSharedHandle>` on Windows
 
 To use GPU texture on Android, instead of setting payload, you can request JNI `Surface` or NDK `ANativeWindow` from the texture:
 

--- a/texture/example/rust/Cargo.toml
+++ b/texture/example/rust/Cargo.toml
@@ -14,7 +14,6 @@ irondash_texture = { version = "0.1.0" }
 irondash_run_loop = { version = "0.1.0" }
 simple_logger = "2.1"
 log = "0.4"
-bytes = "1"
 fastrand = "1.8"
 
 [target.'cfg(target_os = "android")'.dependencies]

--- a/texture/example/rust/src/lib.rs
+++ b/texture/example/rust/src/lib.rs
@@ -1,7 +1,7 @@
 use std::{cell::Cell, iter::repeat_with, rc::Rc, sync::Arc, time::Duration};
 
 use irondash_run_loop::RunLoop;
-use irondash_texture::{BoxedPixelBuffer, PayloadProvider, SimplePixelBuffer, Texture};
+use irondash_texture::{BoxedPixelData, PayloadProvider, SimplePixelData, Texture};
 use log::error;
 
 #[cfg(target_os = "android")]
@@ -27,7 +27,7 @@ fn init_logging() {
 }
 
 struct Animator {
-    texture: Texture<BoxedPixelBuffer>,
+    texture: Texture<BoxedPixelData>,
     counter: Cell<u32>,
 }
 
@@ -39,15 +39,15 @@ impl PixelBufferSource {
     }
 }
 
-impl PayloadProvider<BoxedPixelBuffer> for PixelBufferSource {
-    fn get_payload(&self) -> BoxedPixelBuffer {
+impl PayloadProvider<BoxedPixelData> for PixelBufferSource {
+    fn get_payload(&self) -> BoxedPixelData {
         let rng = fastrand::Rng::new();
         let width = 100i32;
         let height = 100i32;
         let bytes: Vec<u8> = repeat_with(|| rng.u8(..))
             .take((width * height * 4) as usize)
             .collect();
-        SimplePixelBuffer::boxed(width, height, bytes)
+        SimplePixelData::boxed(width, height, bytes)
     }
 }
 

--- a/texture/example/rust/src/lib.rs
+++ b/texture/example/rust/src/lib.rs
@@ -47,7 +47,7 @@ impl PayloadProvider<BoxedPixelData> for PixelBufferSource {
         let bytes: Vec<u8> = repeat_with(|| rng.u8(..))
             .take((width * height * 4) as usize)
             .collect();
-        SimplePixelData::boxed(width, height, bytes)
+        SimplePixelData::new_boxed(width, height, bytes)
     }
 }
 

--- a/texture/example/rust/src/lib.rs
+++ b/texture/example/rust/src/lib.rs
@@ -1,7 +1,7 @@
 use std::{cell::Cell, iter::repeat_with, rc::Rc, sync::Arc, time::Duration};
 
 use irondash_run_loop::RunLoop;
-use irondash_texture::{BoxedPayload, IntoBoxedPayload, PayloadProvider, PixelBuffer, Texture};
+use irondash_texture::{BoxedPixelBuffer, PayloadProvider, SimplePixelBuffer, Texture};
 use log::error;
 
 #[cfg(target_os = "android")]
@@ -27,32 +27,27 @@ fn init_logging() {
 }
 
 struct Animator {
-    texture: Texture<PixelBuffer>,
+    texture: Texture<BoxedPixelBuffer>,
     counter: Cell<u32>,
 }
 
-struct PixelBufferProvider {}
+struct PixelBufferSource {}
 
-impl PixelBufferProvider {
+impl PixelBufferSource {
     fn new() -> Self {
         Self {}
     }
 }
 
-impl PayloadProvider<PixelBuffer> for PixelBufferProvider {
-    fn get_payload(&self) -> BoxedPayload<PixelBuffer> {
+impl PayloadProvider<BoxedPixelBuffer> for PixelBufferSource {
+    fn get_payload(&self) -> BoxedPixelBuffer {
         let rng = fastrand::Rng::new();
         let width = 100i32;
         let height = 100i32;
         let bytes: Vec<u8> = repeat_with(|| rng.u8(..))
             .take((width * height * 4) as usize)
             .collect();
-        let buffer = PixelBuffer {
-            width,
-            height,
-            data: bytes.into(),
-        };
-        buffer.into_boxed_payload()
+        SimplePixelBuffer::boxed(width, height, bytes)
     }
 }
 
@@ -75,7 +70,7 @@ impl Animator {
 }
 
 fn init_on_main_thread(engine_handle: i64) -> irondash_texture::Result<i64> {
-    let provider = Arc::new(PixelBufferProvider::new());
+    let provider = Arc::new(PixelBufferSource::new());
     let texture = Texture::new_with_provider(engine_handle, provider)?;
     let id = texture.id();
 

--- a/texture/src/lib.rs
+++ b/texture/src/lib.rs
@@ -132,7 +132,7 @@ pub trait PixelDataProvider {
 /// Actual type for pixel buffer payload.
 pub type BoxedPixelData = Box<dyn PixelDataProvider>;
 
-/// Convenience implementation for pixel buffer texture.
+/// Convenience implementation for pixel data texture.
 pub struct SimplePixelData {
     width: i32,
     height: i32,
@@ -140,7 +140,7 @@ pub struct SimplePixelData {
 }
 
 impl SimplePixelData {
-    pub fn boxed(width: i32, height: i32, data: Vec<u8>) -> Box<Self> {
+    pub fn new_boxed(width: i32, height: i32, data: Vec<u8>) -> Box<Self> {
         Box::new(Self {
             width,
             height,

--- a/texture/src/platform/darwin/mod.rs
+++ b/texture/src/platform/darwin/mod.rs
@@ -31,7 +31,7 @@ use crate::{
         kIOSurfaceBytesPerElement, kIOSurfaceBytesPerRow, kIOSurfaceHeight, kIOSurfacePixelFormat,
         kIOSurfaceWidth,
     },
-    BoxedIOSurface, BoxedPixelBuffer, IOSurfaceProvider, PayloadProvider, PixelFormat,
+    BoxedIOSurface, BoxedPixelData, IOSurfaceProvider, PayloadProvider, PixelFormat,
     PlatformTextureWithProvider, Result,
 };
 
@@ -52,7 +52,7 @@ impl<Type> PlatformTexture<Type> {
     }
 }
 
-pub(crate) const PIXEL_BUFFER_FORMAT: PixelFormat = PixelFormat::RGBA;
+pub(crate) const PIXEL_DATA_FORMAT: PixelFormat = PixelFormat::RGBA;
 
 impl<Type> PlatformTexture<Type> {
     pub fn new(
@@ -93,12 +93,12 @@ impl<Type> Drop for PlatformTexture<Type> {
     }
 }
 
-impl PlatformTextureWithProvider for BoxedPixelBuffer {
+impl PlatformTextureWithProvider for BoxedPixelData {
     fn create_texture(
         engine_handle: i64,
-        payload_provider: Arc<dyn PayloadProvider<BoxedPixelBuffer>>,
-    ) -> Result<PlatformTexture<BoxedPixelBuffer>> {
-        PlatformTexture::<BoxedPixelBuffer>::new(
+        payload_provider: Arc<dyn PayloadProvider<BoxedPixelData>>,
+    ) -> Result<PlatformTexture<BoxedPixelData>> {
+        PlatformTexture::<BoxedPixelData>::new(
             engine_handle,
             Arc::new(SurfaceAdapter::new(payload_provider)),
         )
@@ -164,12 +164,12 @@ impl PayloadProvider<BoxedIOSurface> for SurfaceCache {
 }
 
 struct SurfaceAdapter {
-    pixel_provider: Arc<dyn PayloadProvider<BoxedPixelBuffer>>,
+    pixel_provider: Arc<dyn PayloadProvider<BoxedPixelData>>,
     cached_surface: Mutex<Option<IOSurface>>,
 }
 
 impl SurfaceAdapter {
-    fn new(pixel_provider: Arc<dyn PayloadProvider<BoxedPixelBuffer>>) -> Self {
+    fn new(pixel_provider: Arc<dyn PayloadProvider<BoxedPixelData>>) -> Self {
         Self {
             pixel_provider,
             cached_surface: Mutex::new(None),


### PR DESCRIPTION
This removes the need for bytes crate and allows more flexible representation of pixel data.