### PR TITLE
Using memcpy in c to directly replace line by line copying #20 

### DIFF
--- a/texture/Cargo.toml
+++ b/texture/Cargo.toml
@@ -18,6 +18,7 @@ log = "0.4"
 irondash_jni_context = { version = "0.1.1" }
 jni = "0.19"
 ndk-sys = "0.4.0"
+libc = "0.2"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 cstr = "0.2.11"


### PR DESCRIPTION
Using memcpy in c to directly replace line by line copying