### PR TITLE
fix: remove usage of gettid on linux

### DIFF
--- a/engine_context/dart/linux/include/irondash_engine_context/irondash_engine_context_plugin.h
+++ b/engine_context/dart/linux/include/irondash_engine_context/irondash_engine_context_plugin.h
@@ -1,10 +1,6 @@
 #ifndef FLUTTER_PLUGIN_ENGINE_CONTEXT_PLUGIN_H_
 #define FLUTTER_PLUGIN_ENGINE_CONTEXT_PLUGIN_H_
 
-#ifndef _GNU_SOURCE
-#define _GNU_SOURCE
-#endif
-
 #include <flutter_linux/flutter_linux.h>
 
 G_BEGIN_DECLS

--- a/engine_context/dart/linux/irondash_engine_context_plugin.cc
+++ b/engine_context/dart/linux/irondash_engine_context_plugin.cc
@@ -23,17 +23,16 @@ struct EngineContext {
 std::map<int64_t, EngineContext> contexts;
 int64_t next_handle = 1;
 std::vector<EngineDestroyedCallback> engine_destroyed_callbacks;
-uint64_t main_thread_id;
+size_t main_thread_id;
 
 __attribute__((constructor)) void Init() {
-  fprintf(stderr, "OnLoad\n");
-  main_thread_id = gettid();
+  main_thread_id = reinterpret_cast<size_t>(pthread_self());
 }
 } // namespace
 
 extern "C" {
 
-uint64_t IrondashEngineContextGetMainThreadId() { return main_thread_id; }
+size_t IrondashEngineContextGetMainThreadId() { return main_thread_id; }
 
 FlView *IrondashEngineContextGetFlutterView(int64_t engine_handle) {
   auto context = contexts.find(engine_handle);

--- a/engine_context/rust/src/platform/linux/mod.rs
+++ b/engine_context/rust/src/platform/linux/mod.rs
@@ -21,7 +21,7 @@ const RTLD_LAZY: c_int = 1;
 extern "C" {
     fn dlopen(filename: *const c_char, flags: c_int) -> *mut c_void;
     fn dlsym(handle: *mut c_void, symbol: *const c_char) -> *mut c_void;
-    pub fn gettid() -> u64;
+    pub fn pthread_self() -> usize;
 }
 
 pub(crate) type FlutterView = FlView;
@@ -31,7 +31,7 @@ pub(crate) type FlutterBinaryMessenger = FlBinaryMessenger;
 type FlView = *mut c_void;
 type FlTextureRegistrar = *mut c_void;
 type FlBinaryMessenger = *mut c_void;
-type GetMainThreadIdProc = unsafe extern "C" fn() -> u64;
+type GetMainThreadIdProc = unsafe extern "C" fn() -> usize;
 type GetFlutterViewProc = unsafe extern "C" fn(i64) -> FlView;
 type RegisterDestroyNotificationProc = unsafe extern "C" fn(extern "C" fn(i64)) -> ();
 type GetFlutterTextureRegistrarProc = unsafe extern "C" fn(i64) -> FlTextureRegistrar;
@@ -81,7 +81,7 @@ impl PlatformContext {
         let proc = Self::get_proc(b"IrondashEngineContextGetMainThreadId\0")?;
         let proc: GetMainThreadIdProc = unsafe { std::mem::transmute(proc) };
         let main_thread_id = unsafe { proc() };
-        let current_thread_id = unsafe { gettid() };
+        let current_thread_id = unsafe { pthread_self() };
         Ok(main_thread_id == current_thread_id)
     }
 

--- a/run_loop/src/platform/linux/mod.rs
+++ b/run_loop/src/platform/linux/mod.rs
@@ -285,8 +285,8 @@ impl PlatformRunLoopSender {
     }
 }
 
-pub(crate) type PlatformThreadId = u64;
+pub(crate) type PlatformThreadId = usize;
 
 pub(crate) fn get_system_thread_id() -> PlatformThreadId {
-    unsafe { libc::gettid() }
+    unsafe { libc::pthread_self() }
 }

--- a/run_loop/src/platform/linux/sys.rs
+++ b/run_loop/src/platform/linux/sys.rs
@@ -66,6 +66,6 @@ pub mod glib {
 #[allow(non_camel_case_types)]
 pub mod libc {
     extern "C" {
-        pub fn gettid() -> u64;
+        pub fn pthread_self() -> usize;
     }
 }


### PR DESCRIPTION
Fixes compilation with glibc older than 2.30.