### PR TITLE
fix compiling on nixos

### DIFF
--- a/engine_context/dart/cargokit/run_build_tool.sh
+++ b/engine_context/dart/cargokit/run_build_tool.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 


### PR DESCRIPTION
On nixos `/bin/bash` is not here, so using `/usr/bin/env bash` is safer