### PR TITLE
fix: use pointer size values where appropriate

### DIFF
--- a/message_channel/dart/lib/src/native_functions.dart
+++ b/message_channel/dart/lib/src/native_functions.dart
@@ -237,7 +237,7 @@ typedef _InitFunction = int Function(Pointer<_GetFunctions>);
 
 final class _GetFunctions extends Struct {
   // in
-  @Int64()
+  @IntPtr()
   external int size;
   external Pointer<Void> ffiData;
 
@@ -270,23 +270,23 @@ final class _GetFunctions extends Struct {
 typedef _RegisterIsolate = Int64 Function(Int64, Handle);
 typedef RegisterIsolate = IsolateId Function(int dartPort, Object isolateId);
 
-typedef _PostMessage = Void Function(Int64, Pointer<Uint8>, Int64);
+typedef _PostMessage = Void Function(Int64, Pointer<Uint8>, IntPtr);
 typedef PostMessage = void Function(IsolateId, Pointer<Uint8>, int len);
 
 typedef _AttachWeakPersistentHandle = Handle Function(
-    Handle, Int64, Handle, Int64);
+    Handle, IntPtr, Handle, Int64);
 typedef AttachWeakPersistentHandle = Object? Function(
     Object, int, Object?, int);
 
-typedef _VecAllocate<T extends NativeType> = Pointer<T> Function(Uint64 size);
+typedef _VecAllocate<T extends NativeType> = Pointer<T> Function(IntPtr size);
 typedef VecAllocate<T extends NativeType> = Pointer<T> Function(int size);
 
 typedef _VecResize<T extends NativeType> = Pointer<T> Function(
-    Pointer<T> oldData, Uint64 oldSize, Uint64 newSize);
+    Pointer<T> oldData, IntPtr oldSize, IntPtr newSize);
 typedef VecResize<T extends NativeType> = Pointer<T> Function(
     Pointer<T> oldData, int oldsize, int newSize);
 
 typedef _VecFree<T extends NativeType> = Void Function(
-    Pointer<T> data, Uint64 size);
+    Pointer<T> data, IntPtr size);
 typedef VecFree<T extends NativeType> = void Function(
     Pointer<T> data, int size);

--- a/message_channel/rust/Cargo.toml
+++ b/message_channel/rust/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/irondash/irondash"
 
 [dependencies]
 once_cell = "1.16.0"
+log = "0.4"
 irondash_dart_ffi = { version = "0.2.0" }
 irondash_run_loop = { version = "0.5.0" }
 async-trait = "0.1"

--- a/message_channel/rust/src/lib.rs
+++ b/message_channel/rust/src/lib.rs
@@ -31,6 +31,7 @@ pub use async_method_handler::*;
 pub use event_channel::*;
 pub use finalizable_handle::*;
 pub use late::*;
+use log::error;
 pub use message_channel::*;
 pub use method_handler::*;
 pub use value::*;
@@ -61,7 +62,7 @@ pub extern "C" fn irondash_init_message_channel_context(_data: *mut c_void) -> F
     {
         #[repr(C)]
         struct MessageChannelContext {
-            size: i64,
+            size: usize,
             ffi_data: *mut c_void,
             register_isolate: *mut c_void,
             send_message: *mut c_void,
@@ -93,8 +94,8 @@ pub extern "C" fn irondash_init_message_channel_context(_data: *mut c_void) -> F
 
         let context = _data as *mut MessageChannelContext;
         let context = unsafe { &mut *context };
-        if context.size != std::mem::size_of::<MessageChannelContext>() as i64 {
-            eprintln!(
+        if context.size != std::mem::size_of::<MessageChannelContext>() {
+            error!(
                 "Bad struct size (expected {}, got {})",
                 std::mem::size_of::<MessageChannelContext>(),
                 context.size

--- a/message_channel/rust/src/message_transport.rs
+++ b/message_channel/rust/src/message_transport.rs
@@ -153,9 +153,9 @@ pub mod native {
     pub(crate) extern "C" fn post_message(
         isolate_id: crate::ffi::IsolateId,
         message: *mut u8,
-        len: u64,
+        len: usize,
     ) {
-        let vec = unsafe { Vec::from_raw_parts(message, len as usize, len as usize) };
+        let vec = unsafe { Vec::from_raw_parts(message, len, len) };
         if let Some(transport) = NativeMessageTransport::get() {
             let isolate_id = IsolateId(isolate_id);
             let value = unsafe { Deserializer::deserialize(&vec) };

--- a/message_channel/rust/src/native_vector.rs
+++ b/message_channel/rust/src/native_vector.rs
@@ -1,92 +1,92 @@
 use std::mem::ManuallyDrop;
 
-unsafe fn allocate_vec<T: Copy + Default>(size: u64) -> *mut T {
-    let mut v = Vec::<T>::with_capacity(size as usize);
-    v.resize(size as usize, T::default());
+unsafe fn allocate_vec<T: Copy + Default>(size: usize) -> *mut T {
+    let mut v = Vec::<T>::with_capacity(size);
+    v.resize(size, T::default());
     assert!(v.capacity() == v.len());
     let res = v.as_mut_ptr();
     let _ = ManuallyDrop::new(v);
     res
 }
 
-pub(super) unsafe extern "C" fn allocate_vec_i8(size: u64) -> *mut i8 {
+pub(super) unsafe extern "C" fn allocate_vec_i8(size: usize) -> *mut i8 {
     allocate_vec::<i8>(size)
 }
 
-pub(super) unsafe extern "C" fn allocate_vec_u8(size: u64) -> *mut u8 {
+pub(super) unsafe extern "C" fn allocate_vec_u8(size: usize) -> *mut u8 {
     allocate_vec::<u8>(size)
 }
 
-pub(super) unsafe extern "C" fn allocate_vec_i16(size: u64) -> *mut i16 {
+pub(super) unsafe extern "C" fn allocate_vec_i16(size: usize) -> *mut i16 {
     allocate_vec::<i16>(size)
 }
 
-pub(super) unsafe extern "C" fn allocate_vec_u16(size: u64) -> *mut u16 {
+pub(super) unsafe extern "C" fn allocate_vec_u16(size: usize) -> *mut u16 {
     allocate_vec::<u16>(size)
 }
 
-pub(super) unsafe extern "C" fn allocate_vec_i32(size: u64) -> *mut i32 {
+pub(super) unsafe extern "C" fn allocate_vec_i32(size: usize) -> *mut i32 {
     allocate_vec::<i32>(size)
 }
 
-pub(super) unsafe extern "C" fn allocate_vec_u32(size: u64) -> *mut u32 {
+pub(super) unsafe extern "C" fn allocate_vec_u32(size: usize) -> *mut u32 {
     allocate_vec::<u32>(size)
 }
 
-pub(super) unsafe extern "C" fn allocate_vec_i64(size: u64) -> *mut i64 {
+pub(super) unsafe extern "C" fn allocate_vec_i64(size: usize) -> *mut i64 {
     allocate_vec::<i64>(size)
 }
 
-pub(super) unsafe extern "C" fn allocate_vec_f32(size: u64) -> *mut f32 {
+pub(super) unsafe extern "C" fn allocate_vec_f32(size: usize) -> *mut f32 {
     allocate_vec::<f32>(size)
 }
 
-pub(super) unsafe extern "C" fn allocate_vec_f64(size: u64) -> *mut f64 {
+pub(super) unsafe extern "C" fn allocate_vec_f64(size: usize) -> *mut f64 {
     allocate_vec::<f64>(size)
 }
 
-pub(super) unsafe extern "C" fn free_vec_i8(data: *mut i8, len: u64) {
-    let _ = Vec::from_raw_parts(data, len as usize, len as usize);
+pub(super) unsafe extern "C" fn free_vec_i8(data: *mut i8, len: usize) {
+    let _ = Vec::from_raw_parts(data, len, len);
 }
 
-pub(super) unsafe extern "C" fn free_vec_u8(data: *mut u8, len: u64) {
-    let _ = Vec::from_raw_parts(data, len as usize, len as usize);
+pub(super) unsafe extern "C" fn free_vec_u8(data: *mut u8, len: usize) {
+    let _ = Vec::from_raw_parts(data, len, len);
 }
 
-pub(super) unsafe extern "C" fn free_vec_i16(data: *mut i16, len: u64) {
-    let _ = Vec::from_raw_parts(data, len as usize, len as usize);
+pub(super) unsafe extern "C" fn free_vec_i16(data: *mut i16, len: usize) {
+    let _ = Vec::from_raw_parts(data, len, len);
 }
 
-pub(super) unsafe extern "C" fn free_vec_u16(data: *mut u16, len: u64) {
-    let _ = Vec::from_raw_parts(data, len as usize, len as usize);
+pub(super) unsafe extern "C" fn free_vec_u16(data: *mut u16, len: usize) {
+    let _ = Vec::from_raw_parts(data, len, len);
 }
 
-pub(super) unsafe extern "C" fn free_vec_i32(data: *mut i32, len: u64) {
-    let _ = Vec::from_raw_parts(data, len as usize, len as usize);
+pub(super) unsafe extern "C" fn free_vec_i32(data: *mut i32, len: usize) {
+    let _ = Vec::from_raw_parts(data, len, len);
 }
 
-pub(super) unsafe extern "C" fn free_vec_u32(data: *mut u32, len: u64) {
-    let _ = Vec::from_raw_parts(data, len as usize, len as usize);
+pub(super) unsafe extern "C" fn free_vec_u32(data: *mut u32, len: usize) {
+    let _ = Vec::from_raw_parts(data, len, len);
 }
 
-pub(super) unsafe extern "C" fn free_vec_i64(data: *mut i64, len: u64) {
-    let _ = Vec::from_raw_parts(data, len as usize, len as usize);
+pub(super) unsafe extern "C" fn free_vec_i64(data: *mut i64, len: usize) {
+    let _ = Vec::from_raw_parts(data, len, len);
 }
 
-pub(super) unsafe extern "C" fn free_vec_f32(data: *mut f32, len: u64) {
-    let _ = Vec::from_raw_parts(data, len as usize, len as usize);
+pub(super) unsafe extern "C" fn free_vec_f32(data: *mut f32, len: usize) {
+    let _ = Vec::from_raw_parts(data, len, len);
 }
 
-pub(super) unsafe extern "C" fn free_vec_f64(data: *mut f64, len: u64) {
-    let _ = Vec::from_raw_parts(data, len as usize, len as usize);
+pub(super) unsafe extern "C" fn free_vec_f64(data: *mut f64, len: usize) {
+    let _ = Vec::from_raw_parts(data, len, len);
 }
 
 unsafe fn modify<T: Copy + Default, F: FnOnce(&mut Vec<T>)>(
     data: *mut T,
-    len: u64,
+    len: usize,
     f: F,
 ) -> *mut T {
-    let mut vec = Vec::<T>::from_raw_parts(data, len as usize, len as usize);
+    let mut vec = Vec::<T>::from_raw_parts(data, len, len);
     f(&mut vec);
     assert!(vec.len() == vec.capacity());
     let res = vec.as_mut_ptr();
@@ -94,9 +94,12 @@ unsafe fn modify<T: Copy + Default, F: FnOnce(&mut Vec<T>)>(
     res
 }
 
-pub(super) unsafe extern "C" fn resize_vec_u8(data: *mut u8, size: u64, new_size: u64) -> *mut u8 {
+pub(super) unsafe extern "C" fn resize_vec_u8(
+    data: *mut u8,
+    size: usize,
+    new_size: usize,
+) -> *mut u8 {
     modify(data, size, |v| {
-        let new_size = new_size as usize;
         if new_size > v.capacity() {
             v.reserve_exact(new_size - v.capacity());
         }


### PR DESCRIPTION
Fixes crash on 32bit platforms and removes unnecessary passing of sizes as 64bits on 32 bit platform.