### PR TITLE
fix darwin default pixel_data_format

### DIFF
--- a/texture/src/platform/darwin/mod.rs
+++ b/texture/src/platform/darwin/mod.rs
@@ -71,7 +71,7 @@ extern_methods!(
     }
 );
 
-pub(crate) const PIXEL_DATA_FORMAT: PixelFormat = PixelFormat::RGBA;
+pub(crate) const PIXEL_DATA_FORMAT: PixelFormat = PixelFormat::BGRA;
 
 impl<Type> PlatformTexture<Type> {
     fn texture_registery(engine_handle: i64) -> Result<Id<FlutterTextureRegistry>> {


### PR DESCRIPTION
default pixel_data_format on macos and ios is bgra