### PR TITLE
fix: build engine_context native library with opt-level=2

### DIFF
--- a/engine_context/dart/android/rust/Cargo.toml
+++ b/engine_context/dart/android/rust/Cargo.toml
@@ -13,6 +13,9 @@ crate-type = ["cdylib"]
 panic = "abort" # required for no_std
 # Must be disabled otherwise dereferences can panic which requres eh_personality.
 debug-assertions = false
+overflow-checks = false
+debug = "none"
+opt-level = 2
 
 [profile.release]
 panic = "abort" # required for no_std


### PR DESCRIPTION
This prevents linking eh_personality with rust 1.78.